### PR TITLE
Added Object.assign polyfill for IE11 compatibility

### DIFF
--- a/src/input-spinner.js
+++ b/src/input-spinner.js
@@ -20,6 +20,31 @@
     factory(jQuery);
   }
 })(function($) {
+  // IE 11 Object.assign polyfill
+  if (typeof Object.assign !== 'function') {
+    Object.defineProperty(Object, "assign", {
+      value: function assign(target, varArgs) { // .length of function is 2
+        'use strict';
+        if (target === null || target === undefined) {
+          throw new TypeError('Cannot convert undefined or null to object');
+        }
+        let to = Object(target);
+        for (let index = 1; index < arguments.length; index++) {
+          const nextSource = arguments[index];
+          if (nextSource !== null && nextSource !== undefined) {
+            for (let nextKey in nextSource) {
+              if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+                to[nextKey] = nextSource[nextKey];
+              }
+            }
+          }
+        }
+        return to;
+      },
+      writable: true,
+      configurable: true
+    });
+  }
   var Spinner;
   var Spinning = function($element, options) {
     this.$el = $element;


### PR DESCRIPTION
Object.assign is missing in ES5 therefore a polyfill is needed to supplement the usage within the source code. Polyfill taken from the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Polyfill).